### PR TITLE
Fix auth error causeb by wrong quota field mapping

### DIFF
--- a/mda/dovecot/dovecot-ldap.conf.ext
+++ b/mda/dovecot/dovecot-ldap.conf.ext
@@ -111,7 +111,7 @@ user_attrs = \
   =home=/home/vmail/%n, \
   =uid=5000, \
   =gid=5000, \
-  =quota_rule=*:bytes=%{ldap:wWWHomePage:_DEFAULT_MAILBOX_SIZE_}
+  =quota_rule=*:bytes=%{ldap:telephoneNumber:_DEFAULT_MAILBOX_SIZE_}
 
 # Filter for user lookup. Some variables can be used (see
 # http://wiki2.dovecot.org/Variables for full list):


### PR DESCRIPTION
As stated in https://www.sysadminsdecuba.com/2020/07/montando-un-servidor-de-correos-con-mailad quota size should be mapped to telephone number [telephoneNumber] and not to Web page [wWWHomePage]