### PR TITLE
Implement DKIM signing for outgoing email.

### DIFF
--- a/amavis/Dockerfile
+++ b/amavis/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p {/var/lib/amavis/tmp,/var/lib/amavis/db} && \
+RUN mkdir -p {/var/lib/amavis/tmp, /var/lib/amavis/db, /var/lib/amavis/dkim} && \
     chown -R amavis:amavis /var/lib/amavis
 
 COPY amavis/ /etc/amavis/

--- a/amavis/amavis/conf.d/50-user
+++ b/amavis/amavis/conf.d/50-user
@@ -16,6 +16,7 @@ $interface_policy{'10024'} = 'MTA';
 
 $policy_bank{'MTA'} = {
   inet_acl => [qw( 127.0.0.1 [::1] 0.0.0.0/0 )],  # restrict access to these IP addresses
+  originating => 1,
   # auth_required_release => 0,  # don't require secret_id for amavisd-release
 };
 

--- a/amavis/docker-compose.yml
+++ b/amavis/docker-compose.yml
@@ -15,6 +15,8 @@ services:
       AMAVIS_MTA: mta
       AMAVIS_SPAMASSASSIN_DISABLED: 1
       AMAVIS_AV_DISABLED: 1
+      AMAVIS_DKIM_SIGNING_DISABLED: 0 
+      AMAVIS_DKIM_DOMAIN: mailad.cu
     ports:
       - "10024:10024"
     volumes:


### PR DESCRIPTION
- MUST add txt field on DNS server for dkim to work.
- TXT field value can be obtained in different ways 
    1- On amavis startup logs 
    2- cat /var/lib/amavis/dkim/your.domain.org.txt 
    3- Attach to amavis container and run /usr/sbin/amavisd-new showkeys your.domain.org