### PR TITLE
Fix amavis, spammassasin and dkim conditional checks

### DIFF
--- a/amavis/docker-entrypoint.sh
+++ b/amavis/docker-entrypoint.sh
@@ -9,7 +9,7 @@ fi
 
 SPAM=NO
 # spamassasin enabled
-if [ -z "${AMAVIS_SPAMASSASSIN_DISABLED}" ] ; then
+if [ -z "${AMAVIS_SPAMASSASSIN_DISABLED}" ] || [ "${AMAVIS_SPAMASSASSIN_DISABLED}" = "0" ] ; then
     # enable it
     echo '@bypass_spam_checks_maps = ( \%bypass_spam_checks, \@bypass_spam_checks_acl, \$bypass_spam_checks_re); ' >> /etc/amavis/conf.d/15-content_filter_mode
     SPAM=YES
@@ -19,7 +19,7 @@ else
 fi
 
 # AV enabled
-if [ -z "${AMAVIS_AV_DISABLED}" ] ; then
+if [ -z "${AMAVIS_AV_DISABLED}" ] || [ "${AMAVIS_AV_DISABLED}" = "0" ] ; then
     # enable av
     echo '@bypass_virus_checks_maps = ( \%bypass_virus_checks, \@bypass_virus_checks_acl, \$bypass_virus_checks_re);' >> /etc/amavis/conf.d/15-content_filter_mode
     echo "AV Enabled by default!!!"
@@ -28,7 +28,7 @@ else
 fi
 
 #if dkim signing enabled
-if [ ! -z "${AMAVIS_DKIM_SIGNING_DISABLED}" ] ; then
+if [ -z "${AMAVIS_DKIM_SIGNING_DISABLED}" ] || [ "${AMAVIS_DKIM_SIGNING_DISABLED}" = "0" ] ; then
   # check for DKIM domain configuration
   if [[ ! -z "${AMAVIS_DKIM_DOMAIN}" ]] ; then
     echo "Setup DKIM signing"

--- a/amavis/docker-entrypoint.sh
+++ b/amavis/docker-entrypoint.sh
@@ -32,7 +32,7 @@ if [ -z "${AMAVIS_DKIM_SIGNING_DISABLED}" ] || [ "${AMAVIS_DKIM_SIGNING_DISABLED
   # check for DKIM domain configuration
   if [[ ! -z "${AMAVIS_DKIM_DOMAIN}" ]] ; then
     echo "Setup DKIM signing"
-    echo '$enable_dkim_signing = 1;' >> /etc/amavis/conf.d/22-dkim_signing
+    echo '$enable_dkim_signing = 1;' > /etc/amavis/conf.d/22-dkim_signing
     #Generate domain key
     if [[ ! -f "/var/lib/amavis/dkim/${AMAVIS_DKIM_DOMAIN}.pem" ]] ; then
         echo "DKIM key not present for domain ${AMAVIS_DKIM_DOMAIN} ...generating!!!"

--- a/clamav/docker-compose.yml
+++ b/clamav/docker-compose.yml
@@ -14,7 +14,9 @@ services:
     environment:
       # CLAMAV_PROXY_SERVER: 10.1.2.3
       # CLAMAV_PROXY_PORT: 3128
+      #CLAMAV_MIRROR_CUSTOM_URL: 0
       CLAMAV_ALTERNATE_MIRROR: clamav.ddns.net
+     
     ports:
       - "3310:3310"
     volumes:

--- a/clamav/docker-entrypoint.sh
+++ b/clamav/docker-entrypoint.sh
@@ -13,6 +13,14 @@ if [ ! -f /etc/clamav/configured ] ; then
     if [ ! -z "${CLAMAV_ALTERNATE_MIRROR}" ]; then
         sed -i s/"DatabaseMirror .*$"/""/g /etc/clamav/freshclam.conf
         echo "DatabaseMirror ${CLAMAV_ALTERNATE_MIRROR}" >> /etc/clamav/freshclam.conf
+        
+        if [ ! -z "${CLAMAV_MIRROR_CUSTOM_URL}" ] && [ "${CLAMAV_MIRROR_CUSTOM_URL}" = 1 ]; then
+            echo "PrivateMirror ${CLAMAV_ALTERNATE_MIRROR}" >> /etc/clamav/freshclam.conf
+            echo "DatabaseCustomURL http://${CLAMAV_ALTERNATE_MIRROR}/main.cvd" >> /etc/clamav/freshclam.conf
+            echo "DatabaseCustomURL http://${CLAMAV_ALTERNATE_MIRROR}/daily.cvd" >> /etc/clamav/freshclam.conf
+            echo "DatabaseCustomURL http://${CLAMAV_ALTERNATE_MIRROR}/bytecode.cvd" >> /etc/clamav/freshclam.conf
+            echo "DatabaseCustomURL http://${CLAMAV_ALTERNATE_MIRROR}/safebrowsing.cvd" >> /etc/clamav/freshclam.conf
+        fi
     fi
 
     touch /etc/clamav/configured

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -96,6 +96,7 @@ services:
     environment:
       # CLAMAV_PROXY_SERVER: 10.1.2.3
       # CLAMAV_PROXY_PORT: 3128
+      #CLAMAV_MIRROR_CUSTOM_URL: 0
       CLAMAV_ALTERNATE_MIRROR: clamav.ddns.net
     ports:
       - "3310"


### PR DESCRIPTION
1- Implement the env var CLAMAV_MIRROR_CUSTOM_URL (a bool):
 if set to 1 will config the following custom urls for fetching updates:
http://${CLAMAV_ALTERNATE_MIRROR}/main.cvd"
http://${CLAMAV_ALTERNATE_MIRROR}/daily.cvd"
http://${CLAMAV_ALTERNATE_MIRROR}/bytecode.cvd"
http://${CLAMAV_ALTERNATE_MIRROR}/safebrowsing.cvd"

2- Fix checks for ( AMAVIS_SPAMASSASSIN_DISABLED, AMAVIS_AV_DISABLED and AMAVIS_DKIM_SIGNING_DISABLED ) causing features being enabled when desired behaviour was the opposite.
